### PR TITLE
Increasing Kafka response timeout to 60 s. This is a high value but n…

### DIFF
--- a/backend/kafka/kafkarpc.js
+++ b/backend/kafka/kafkarpc.js
@@ -2,7 +2,7 @@
 const crypto = require("crypto");
 const conn = require("./connection");
 
-const TIMEOUT = 8000; //time to wait for response in ms
+const TIMEOUT = 60000; //time to wait for response in ms
 var self;
 
 function KafkaRPC() {


### PR DESCRIPTION
…eeded because server crashes for large no. of requests with current value